### PR TITLE
Fix inability to load vocab.json on converting the 16B model due to encoding of the file not being set

### DIFF
--- a/convert-codegen-to-ggml.py
+++ b/convert-codegen-to-ggml.py
@@ -59,7 +59,7 @@ if len(sys.argv) < 3:
 dir_model = sys.argv[1]
 fname_out = sys.argv[1] + "/ggml-model.bin"
 
-with open(dir_model + "/vocab.json", "r") as f:
+with open(dir_model + "/vocab.json", "r", encoding="utf8") as f:
     encoder = json.load(f)
 
 with open(dir_model + "/added_tokens.json", "r") as f:


### PR DESCRIPTION
Today I was trying to convert the 16B model using the python script but kept runing into the error
`
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 926: character maps to <undefined>
`

having a look into it, the error seems to occur as the encoding of the file is not set to UTF-8 when it is opened by the script. Tested change on my personal machine and it converted the model fine without any errors